### PR TITLE
shallow-clone DVWA

### DIFF
--- a/Install-DVWA.sh
+++ b/Install-DVWA.sh
@@ -336,7 +336,7 @@ if [ -d "/var/www/html/DVWA" ]; then
 
         # Download DVWA from GitHub
         echo -e "$(get_translation "downloading_dvwa" "$lang")"
-        git clone https://github.com/digininja/DVWA.git /var/www/html/DVWA
+        git clone --depth=1 https://github.com/digininja/DVWA.git /var/www/html/DVWA
         sleep 2
     elif [[ "$force_download" == "n" ]]; then
         # User chooses not to download
@@ -349,7 +349,7 @@ if [ -d "/var/www/html/DVWA" ]; then
 else
     # Folder does not exist, download DVWA from GitHub
     echo -e "$(get_translation "downloading_dvwa" "$lang")"
-    git clone https://github.com/digininja/DVWA.git /var/www/html/DVWA
+    git clone --depth=1 https://github.com/digininja/DVWA.git /var/www/html/DVWA
     sleep 2
 fi
 


### PR DESCRIPTION
This should speed-up the download and will reduce bandwidth use.

I didn't add [`--filter=blob:none`](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone) because it's unlikely that users will `fetch`/`pull` anytime after cloning.

> [!note]
> Despite what that link suggests, a `clone` *can be both partial and shallow* at the same time. However, there's no need for that, in this case